### PR TITLE
Drawing task values

### DIFF
--- a/lib/classify-page.js
+++ b/lib/classify-page.js
@@ -116,6 +116,16 @@
         };
       })(this));
       this.decisionTreeContainer.append(this.decisionTree.el);
+      this.listenTo(this.subjectViewer.markingSurface, 'marking-surface:add-tool', (function(_this) {
+        return function() {
+          return _this.updateDrawingTask();
+        };
+      })(this));
+      this.listenTo(this.subjectViewer.markingSurface, 'marking-surface:remove-tool', (function(_this) {
+        return function() {
+          return _this.updateDrawingTask();
+        };
+      })(this));
       this.summary = new ClassificationSummary;
       this.summary.on(this.summary.DISMISS, (function(_this) {
         return function() {
@@ -290,7 +300,7 @@
     };
 
     ClassifyPage.prototype.composeAnnotations = function() {
-      var annotations, decisionTreeValues, key, keyAndValue, mark, task, value, _i, _j, _len, _len1, _ref;
+      var annotations, decisionTreeValues, key, keyAndValue, value, _i, _len;
       annotations = [];
       decisionTreeValues = this.decisionTree.getValues();
       for (_i = 0, _len = decisionTreeValues.length; _i < _len; _i++) {
@@ -301,14 +311,6 @@
             key: key,
             value: value
           });
-        }
-      }
-      _ref = this.subjectViewer.markingSurface.tools;
-      for (_j = 0, _len1 = _ref.length; _j < _len1; _j++) {
-        mark = _ref[_j].mark;
-        task = annotations[mark._taskIndex];
-        if (task != null) {
-          task.value.push(mark);
         }
       }
       return annotations;
@@ -339,6 +341,19 @@
         }
       });
       return prompt.show();
+    };
+
+    ClassifyPage.prototype.updateDrawingTask = function() {
+      var mark, marks, _i, _len, _ref, _ref1;
+      marks = [];
+      _ref = this.subjectViewer.markingSurface.tools;
+      for (_i = 0, _len = _ref.length; _i < _len; _i++) {
+        mark = _ref[_i].mark;
+        if (mark._taskIndex === this.subjectViewer.taskIndex) {
+          marks.push(mark);
+        }
+      }
+      return (_ref1 = this.decisionTree.currentTask) != null ? _ref1.reset(marks) : void 0;
     };
 
     ClassifyPage.prototype.events = {

--- a/lib/classify-page.js
+++ b/lib/classify-page.js
@@ -300,19 +300,11 @@
     };
 
     ClassifyPage.prototype.composeAnnotations = function() {
-      var annotations, decisionTreeValues, key, keyAndValue, mark, task, value, _i, _j, _len, _len1, _ref;
+      var annotations, decisionTreeValues, key, keyAndValue, value, _i, _len;
       annotations = [];
-      _ref = this.subjectViewer.markingSurface.tools;
-      for (_i = 0, _len = _ref.length; _i < _len; _i++) {
-        mark = _ref[_i].mark;
-        task = annotations[mark._taskIndex];
-        if (task != null) {
-          task.addMark(mark);
-        }
-      }
       decisionTreeValues = this.decisionTree.getValues();
-      for (_j = 0, _len1 = decisionTreeValues.length; _j < _len1; _j++) {
-        keyAndValue = decisionTreeValues[_j];
+      for (_i = 0, _len = decisionTreeValues.length; _i < _len; _i++) {
+        keyAndValue = decisionTreeValues[_i];
         for (key in keyAndValue) {
           value = keyAndValue[key];
           annotations.push({

--- a/src/classify-page.coffee
+++ b/src/classify-page.coffee
@@ -208,12 +208,6 @@ class ClassifyPage extends Classifier
 
   composeAnnotations: ->
     annotations = []
-    
-    for {mark} in @subjectViewer.markingSurface.tools
-      # A drawing task's value is the last-selected tool, which is not terribly
-      # useful. Replace it with the task's marks.
-      task = annotations[mark._taskIndex]
-      task.addMark mark if task?
 
     decisionTreeValues = @decisionTree.getValues()
     for keyAndValue in decisionTreeValues then for key, value of keyAndValue

--- a/src/classify-page.coffee
+++ b/src/classify-page.coffee
@@ -78,6 +78,12 @@ class ClassifyPage extends Classifier
       @finishSubject()
 
     @decisionTreeContainer.append @decisionTree.el
+    
+    @listenTo @subjectViewer.markingSurface, 'marking-surface:add-tool', =>
+      @updateDrawingTask()
+      
+    @listenTo @subjectViewer.markingSurface, 'marking-surface:remove-tool', =>
+      @updateDrawingTask()
 
     @summary = new ClassificationSummary
 
@@ -207,12 +213,6 @@ class ClassifyPage extends Classifier
     for keyAndValue in decisionTreeValues then for key, value of keyAndValue
       annotations.push {key, value}
 
-    for {mark} in @subjectViewer.markingSurface.tools
-      # A drawing task's value is the last-selected tool, which is not terribly
-      # useful. Replace it with the task's marks.
-      task = annotations[mark._taskIndex]
-      task?.value.push mark
-
     annotations
 
   promptToLogIn: ->
@@ -244,6 +244,13 @@ class ClassifyPage extends Classifier
         setTimeout (=> @destroy()), 600
 
     prompt.show()
+  
+  updateDrawingTask: ->
+    marks = []
+    for {mark} in @subjectViewer.markingSurface.tools
+      marks.push mark if mark._taskIndex is @subjectViewer.taskIndex
+    
+    @decisionTree.currentTask?.reset marks
 
   events:
     'change input[name="favorite"]': (e) ->


### PR DESCRIPTION
Listen for changes in the marking surface and store marks for the current task as the task value. Replaces the hack in the composeAnnotations() method.